### PR TITLE
Fixes and Enhancements

### DIFF
--- a/UITableView+LongPressReorder/UITableView+LongPressReorder.h
+++ b/UITableView+LongPressReorder/UITableView+LongPressReorder.h
@@ -25,8 +25,11 @@
 
 @interface UITableView (LongPressReorder)
 
+@property (nonatomic, weak) id <LPRTableViewDelegate> lprDelegate;
 @property (nonatomic, assign, getter = isLongPressReorderEnabled) BOOL longPressReorderEnabled;
-@property (nonatomic, assign) id <LPRTableViewDelegate> lprDelegate;
+@property (nonatomic, assign, readonly) BOOL isLongPressReordering;
+@property (nonatomic, assign) CGFloat draggingViewScale;
+@property (nonatomic, assign) BOOL draggingViewIsCentered;
 
 @end
 

--- a/UITableView+LongPressReorder/UITableView+LongPressReorder.m
+++ b/UITableView+LongPressReorder/UITableView+LongPressReorder.m
@@ -15,11 +15,13 @@
 
 @property (nonatomic, readonly) UITableView *tableView;
 @property (nonatomic, assign) CGFloat draggingViewOpacity;
+@property (nonatomic, assign) CGFloat draggingViewScale;
+@property (nonatomic, assign) BOOL draggingViewIsCentered;
 @property (nonatomic, assign) BOOL canReorder;
 @property (nonatomic, strong) UILongPressGestureRecognizer *longPress;
 @property (nonatomic, strong) CADisplayLink *scrollDisplayLink;
 @property (nonatomic, assign) CGFloat scrollRate;
-@property (nonatomic, strong) NSIndexPath *currentLocationIndexPath;
+@property (nonatomic, strong) NSIndexPath *currentIndexPath;
 @property (nonatomic, strong) NSIndexPath *initialIndexPath;
 @property (nonatomic, strong) UIView *draggingView;
 
@@ -37,6 +39,7 @@
 
         _canReorder = YES;
         _draggingViewOpacity = 0.85;
+        _draggingViewScale = 1;
         _longPress.enabled = _canReorder;
     }
     
@@ -46,12 +49,17 @@
 - (void)setCanReorder:(BOOL)canReorder {
     _canReorder = canReorder;
     _longPress.enabled = _canReorder;
+    if (!canReorder) {
+        [self stopDisplayLinkUpdating];
+        [self removeDraggingView];
+    }
 }
 
 - (void)longPress:(UILongPressGestureRecognizer *)gesture {
     
-    CGPoint location = [gesture locationInView:_tableView];
-    NSIndexPath *indexPath = [_tableView indexPathForRowAtPoint:location];
+    CGPoint locationInContainer = [self locationInContainer:gesture];
+    CGPoint locationInTable = [gesture locationInView:_tableView];
+    NSIndexPath *indexPath = [_tableView indexPathForRowAtPoint:locationInTable];
     
     int sections = [_tableView numberOfSections];
     int rows = 0;
@@ -62,7 +70,7 @@
     // get out of here if the long press was not on a valid row or our table is empty
     // or the dataSource tableView:canMoveRowAtIndexPath: doesn't allow moving the row
     if (rows == 0 || (gesture.state == UIGestureRecognizerStateBegan && indexPath == nil) ||
-        (gesture.state == UIGestureRecognizerStateEnded && self.currentLocationIndexPath == nil) ||
+        (gesture.state == UIGestureRecognizerStateEnded && self.currentIndexPath == nil) ||
         (gesture.state == UIGestureRecognizerStateBegan &&
          [_tableView.dataSource respondsToSelector:@selector(tableView:canMoveRowAtIndexPath:)] &&
          indexPath && ![_tableView.dataSource tableView:_tableView canMoveRowAtIndexPath:indexPath])) {
@@ -82,73 +90,71 @@
             if ([(id)_tableView.lprDelegate respondsToSelector:@selector(tableView:draggingViewForCellAtIndexPath:)]) {
                 _draggingView = [_tableView.lprDelegate tableView:_tableView draggingViewForCellAtIndexPath:indexPath];
             } else {
-                // make an image from the pressed tableview cell
-                UIGraphicsBeginImageContextWithOptions(cell.bounds.size, NO, 0);
-                [cell.layer renderInContext:UIGraphicsGetCurrentContext()];
-                UIImage *cellImage = UIGraphicsGetImageFromCurrentImageContext();
-                UIGraphicsEndImageContext();
-
-                _draggingView = [[UIImageView alloc] initWithImage:cellImage];
+                // make a snapshot from the pressed tableview cell
+                _draggingView = [cell snapshotViewAfterScreenUpdates:NO];
+                if (!_draggingView) {
+                    // make an image from the pressed tableview cell
+                    UIGraphicsBeginImageContextWithOptions(cell.bounds.size, NO, 0);
+                    [cell drawViewHierarchyInRect:cell.bounds afterScreenUpdates:YES];
+                    UIImage *cellImage = UIGraphicsGetImageFromCurrentImageContext();
+                    UIGraphicsEndImageContext();
+                    _draggingView = [[UIImageView alloc] initWithImage:cellImage];
+                }
             }
             
-            [_tableView addSubview:_draggingView];
-            CGRect rect = [_tableView rectForRowAtIndexPath:indexPath];
-            _draggingView.frame = CGRectOffset(_draggingView.bounds, rect.origin.x, rect.origin.y);
+            [[self container] addSubview:_draggingView];
+            CGRect frame = [self rowFrameInContainer:indexPath];
+            _draggingView.frame = CGRectOffset(_draggingView.bounds, frame.origin.x, frame.origin.y);
             
             // add a show animation
-            [UIView beginAnimations:@"show" context:nil];
-            if ([(id)_tableView.lprDelegate respondsToSelector:@selector(tableView:showDraggingView:atIndexPath:)]) {
-                [_tableView.lprDelegate tableView:_tableView showDraggingView:_draggingView atIndexPath:indexPath];
-            } else {
-                // add drop shadow to image and lower opacity
-                _draggingView.layer.masksToBounds = NO;
-                _draggingView.layer.shadowColor = [[UIColor blackColor] CGColor];
-                _draggingView.layer.shadowOffset = CGSizeMake(0, 0);
-                _draggingView.layer.shadowRadius = 2.0;
-                _draggingView.layer.shadowOpacity = 0.5;
-                _draggingView.layer.opacity = self.draggingViewOpacity;
-                
-                _draggingView.transform = CGAffineTransformMakeScale(1, 1);
-                _draggingView.center = CGPointMake(_tableView.center.x, location.y);
-            }
-            [UIView commitAnimations];
+            [UIView animateWithDuration:0.3
+                             animations:^{
+                                 if ([(id)_tableView.lprDelegate respondsToSelector:@selector(tableView:showDraggingView:atIndexPath:)]) {
+                                     [_tableView.lprDelegate tableView:_tableView showDraggingView:_draggingView atIndexPath:indexPath];
+                                 }
+                                 // add drop shadow to image and lower opacity
+                                 _draggingView.layer.masksToBounds = NO;
+                                 _draggingView.layer.shadowColor = [[UIColor blackColor] CGColor];
+                                 _draggingView.layer.shadowOffset = CGSizeMake(0, 0);
+                                 _draggingView.layer.shadowRadius = 2.0;
+                                 _draggingView.layer.shadowOpacity = 0.5;
+                                 _draggingView.layer.opacity = self.draggingViewOpacity;
+                                 
+                                 _draggingView.transform = CGAffineTransformMakeScale(_draggingViewScale, _draggingViewScale);
+                                 _draggingView.center = CGPointMake(_draggingViewIsCentered ? _tableView.center.x : locationInContainer.x, locationInContainer.y);
+                             }];
         }
         
         cell.hidden = YES;
         
-        self.currentLocationIndexPath = indexPath;
+        self.currentIndexPath = indexPath;
         self.initialIndexPath = indexPath;
         
         // enable scrolling for cell
-        self.scrollDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(scrollTableWithCell:)];
-        [self.scrollDisplayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];        
+        [self startDisplayLinkUpdating];
     }
     // dragging
     else if (gesture.state == UIGestureRecognizerStateChanged) {
         // update position of the drag view
-        // don't let it go past the top or the bottom too far
-        if (location.y >= 0 && location.y <= _tableView.contentSize.height + 50) {
-            _draggingView.center = CGPointMake(_tableView.center.x, location.y);
-        }
+        _draggingView.center = CGPointMake(_draggingViewIsCentered ? _tableView.center.x : locationInContainer.x, locationInContainer.y);
+        
+        [self updateCurrentIndexPath:gesture];
         
         CGRect rect = _tableView.bounds;
         // adjust rect for content inset as we will use it below for calculating scroll zones
         rect.size.height -= _tableView.contentInset.top;
-        CGPoint location = [gesture locationInView:_tableView];
-        
-        [self updateCurrentLocation:gesture];
         
         // tell us if we should scroll and which direction
         CGFloat scrollZoneHeight = rect.size.height / 6;
         CGFloat bottomScrollBeginning = _tableView.contentOffset.y + _tableView.contentInset.top + rect.size.height - scrollZoneHeight;
         CGFloat topScrollBeginning = _tableView.contentOffset.y + _tableView.contentInset.top  + scrollZoneHeight;
         // we're in the bottom zone
-        if (location.y >= bottomScrollBeginning) {
-            _scrollRate = (location.y - bottomScrollBeginning) / scrollZoneHeight;
+        if (locationInTable.y >= bottomScrollBeginning) {
+            _scrollRate = (locationInTable.y - bottomScrollBeginning) / scrollZoneHeight;
         }
         // we're in the top zone
-        else if (location.y <= topScrollBeginning) {
-            _scrollRate = (location.y - topScrollBeginning) / scrollZoneHeight;
+        else if (locationInTable.y <= topScrollBeginning) {
+            _scrollRate = (locationInTable.y - topScrollBeginning) / scrollZoneHeight;
         }
         else {
             _scrollRate = 0;
@@ -156,79 +162,72 @@
     }
     // dropped
     else if (gesture.state == UIGestureRecognizerStateEnded) {
-        
-        NSIndexPath *indexPath = self.currentLocationIndexPath;
+        NSIndexPath *indexPath = self.currentIndexPath;
         
         // remove scrolling CADisplayLink
-        [_scrollDisplayLink invalidate];
-        _scrollDisplayLink = nil;
-        _scrollRate = 0;
+        [self stopDisplayLinkUpdating];
         
         // animate the drag view to the newly hovered cell
-        [UIView animateWithDuration:0.3
-                         animations:^{
-                             if ([(id)_tableView.lprDelegate respondsToSelector:@selector(tableView:hideDraggingView:atIndexPath:)]) {
-                                 [_tableView.lprDelegate tableView:_tableView hideDraggingView:_draggingView atIndexPath:indexPath];
-                             } else {
-                                 CGRect rect = [_tableView rectForRowAtIndexPath:indexPath];
+        if (_draggingView) {
+            [UIView animateWithDuration:0.3
+                             animations:^{
+                                 if ([(id)_tableView.lprDelegate respondsToSelector:@selector(tableView:hideDraggingView:atIndexPath:)]) {
+                                     [_tableView.lprDelegate tableView:_tableView hideDraggingView:_draggingView atIndexPath:indexPath];
+                                 }
+                                 CGRect frame = [self rowFrameInContainer:indexPath];
                                  _draggingView.transform = CGAffineTransformIdentity;
-                                 _draggingView.frame = CGRectOffset(_draggingView.bounds, rect.origin.x, rect.origin.y);
-                             }
-                         } completion:^(BOOL finished) {
-                             [_tableView beginUpdates];
-                             [_tableView deleteRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationNone];
-                             [_tableView insertRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationNone];
-                             [_tableView endUpdates];
-                             
-                             [_draggingView removeFromSuperview];
-                             
-                             // reload the rows that were affected just to be safe
-                             NSMutableArray *visibleRows = [[_tableView indexPathsForVisibleRows] mutableCopy];
-                             [visibleRows removeObject:indexPath];
-                             [_tableView reloadRowsAtIndexPaths:visibleRows withRowAnimation:UITableViewRowAnimationNone];
-                             
-                             _currentLocationIndexPath = nil;
-                             _draggingView = nil;
-                         }];
+                                 _draggingView.frame = CGRectOffset(_draggingView.bounds, frame.origin.x, frame.origin.y);
+                             } completion:^(BOOL finished) {
+                                 [_tableView beginUpdates];
+                                 [_tableView deleteRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationNone];
+                                 [_tableView insertRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationNone];
+                                 [_tableView endUpdates];
+                                 
+                                 [self removeDraggingView];
+                                 
+                                 // reload the rows that were affected just to be safe
+                                 NSMutableArray *visibleRows = [[_tableView indexPathsForVisibleRows] mutableCopy];
+                                 [visibleRows removeObject:indexPath];
+                                 [_tableView reloadRowsAtIndexPaths:visibleRows withRowAnimation:UITableViewRowAnimationNone];
+                                 
+                                 _currentIndexPath = nil;
+                             }];
+        }
     }
 }
 
-
-- (void)updateCurrentLocation:(UILongPressGestureRecognizer *)gesture {
-    
-    NSIndexPath *indexPath  = nil;
-    CGPoint location = CGPointZero;
-    
+- (void)updateCurrentIndexPath:(UILongPressGestureRecognizer *)gesture {
     // refresh index path
-    location  = [gesture locationInView:_tableView];
-    indexPath = [_tableView indexPathForRowAtPoint:location];
+    CGPoint location  = [gesture locationInView:_tableView];
+    NSIndexPath *newIndexPath = [_tableView indexPathForRowAtPoint:location];
+    NSIndexPath *oldIndexPath = self.currentIndexPath;
     
     if ([_tableView.delegate respondsToSelector:@selector(tableView:targetIndexPathForMoveFromRowAtIndexPath:toProposedIndexPath:)]) {
-        indexPath = [_tableView.delegate tableView:_tableView targetIndexPathForMoveFromRowAtIndexPath:self.initialIndexPath toProposedIndexPath:indexPath];
+        newIndexPath = [_tableView.delegate tableView:_tableView targetIndexPathForMoveFromRowAtIndexPath:self.initialIndexPath toProposedIndexPath:newIndexPath];
     }
     
-    NSInteger oldHeight = [_tableView rectForRowAtIndexPath:self.currentLocationIndexPath].size.height;
-    NSInteger newHeight = [_tableView rectForRowAtIndexPath:indexPath].size.height;
+    NSInteger oldHeight = [_tableView rectForRowAtIndexPath:oldIndexPath].size.height;
+    NSInteger newHeight = [_tableView rectForRowAtIndexPath:newIndexPath].size.height;
     
-    if (indexPath && ![indexPath isEqual:self.currentLocationIndexPath] && [gesture locationInView:[_tableView cellForRowAtIndexPath:indexPath]].y > newHeight - oldHeight) {
+    if (newIndexPath && ![newIndexPath isEqual:oldIndexPath] &&
+        [gesture locationInView:[_tableView cellForRowAtIndexPath:newIndexPath]].y > newHeight - oldHeight) {
         [_tableView beginUpdates];
-        [_tableView moveRowAtIndexPath:self.currentLocationIndexPath toIndexPath:indexPath];
+        [_tableView moveRowAtIndexPath:self.currentIndexPath toIndexPath:newIndexPath];
         
         if ([(id)_tableView.dataSource respondsToSelector:@selector(tableView:moveRowAtIndexPath:toIndexPath:)]) {
-            [_tableView.dataSource tableView:_tableView moveRowAtIndexPath:self.currentLocationIndexPath toIndexPath:indexPath];
-        }
-        else {
+            [_tableView.dataSource tableView:_tableView moveRowAtIndexPath:self.currentIndexPath toIndexPath:newIndexPath];
+        } else {
             NSLog(@"moveRowAtIndexPath:toIndexPath: is not implemented");
         }
-        
-        _currentLocationIndexPath = indexPath;
         [_tableView endUpdates];
+        
+        _currentIndexPath = newIndexPath;
     }
 }
 
 - (void)scrollTableWithCell:(NSTimer *)timer {    
     UILongPressGestureRecognizer *gesture = _longPress;
-    CGPoint location  = [gesture locationInView:_tableView];
+    CGPoint locationInContainer  = [self locationInContainer:gesture];
     
     CGPoint currentOffset = _tableView.contentOffset;
     CGPoint newOffset = CGPointMake(currentOffset.x, currentOffset.y + self.scrollRate * 10);
@@ -241,18 +240,50 @@
         newOffset.y = (_tableView.contentSize.height + _tableView.contentInset.bottom) - _tableView.frame.size.height;
     }
     
-    [_tableView setContentOffset:newOffset];
-    
-    if (location.y >= 0 && location.y <= _tableView.contentSize.height + 50) {
-        _draggingView.center = CGPointMake(_tableView.center.x, location.y);
+    if (newOffset.y != currentOffset.y) {
+        [_tableView setContentOffset:newOffset];
+        [self updateCurrentIndexPath:gesture];
+        
+        // In case if the cell is regenerated by `- tableView:cellForRowAtIndexPath:`, set it hidden again
+        [_tableView cellForRowAtIndexPath:self.currentIndexPath].hidden = YES;
     }
     
-    [self updateCurrentLocation:gesture];
+    if (_draggingView.center.y != locationInContainer.y) {
+        _draggingView.center = CGPointMake(_draggingViewIsCentered ? _tableView.center.x : locationInContainer.x, locationInContainer.y);
+    }
+}
+
+- (UIView *)container {
+    return _tableView.window;
+}
+
+- (CGPoint)locationInContainer:(UIGestureRecognizer *)gestureRecognizer {
+    return [gestureRecognizer locationInView:[self container]];
+}
+
+- (CGRect)rowFrameInContainer:(NSIndexPath *)indexPath {
+    return [[self container] convertRect:[_tableView rectForRowAtIndexPath:indexPath] fromView:_tableView];
 }
 
 - (void)cancelGesture {
     _longPress.enabled = NO;
     _longPress.enabled = YES;
+}
+
+- (void)startDisplayLinkUpdating {
+    self.scrollDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(scrollTableWithCell:)];
+    [self.scrollDisplayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+}
+
+- (void)stopDisplayLinkUpdating {
+    [_scrollDisplayLink invalidate];
+    _scrollDisplayLink = nil;
+    _scrollRate = 0;
+}
+
+- (void)removeDraggingView {
+    [_draggingView removeFromSuperview];
+    _draggingView = nil;
 }
 
 @end
@@ -265,7 +296,7 @@ static void *LPRDelegateKey = &LPRDelegateKey;
 - (void)setLprDelegate:(id<LPRTableViewDelegate>)LPRDelegate {
     id delegate = objc_getAssociatedObject(self, LPRDelegateKey);
     if (delegate != LPRDelegate) {
-        objc_setAssociatedObject(self, LPRDelegateKey, LPRDelegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, LPRDelegateKey, LPRDelegate, OBJC_ASSOCIATION_ASSIGN);
     }
 }
 
@@ -303,6 +334,26 @@ static void *LPRProxyKey = &LPRProxyKey;
         objc_setAssociatedObject(self, LPRProxyKey, proxy, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     return proxy;
+}
+
+- (BOOL)isLongPressReordering {
+    return [self lprProxy].draggingView != nil;
+}
+
+- (void)setDraggingViewScale:(CGFloat)draggingViewScale {
+    [[self lprProxy] setDraggingViewScale:draggingViewScale];
+}
+
+- (CGFloat)draggingViewScale {
+    return [self lprProxy].draggingViewScale;
+}
+
+- (void)setDraggingViewIsCentered:(BOOL)draggingViewIsCentered {
+    [[self lprProxy] setDraggingViewIsCentered:draggingViewIsCentered];
+}
+
+- (BOOL)draggingViewIsCentered {
+    return [self lprProxy].draggingViewIsCentered;
 }
 
 @end

--- a/UITableView+LongPressReorder/UITableView+LongPressReorder.m
+++ b/UITableView+LongPressReorder/UITableView+LongPressReorder.m
@@ -130,6 +130,8 @@
         self.currentIndexPath = indexPath;
         self.initialIndexPath = indexPath;
         
+        [self tapticEngineFeedback];
+        
         // enable scrolling for cell
         [self startDisplayLinkUpdating];
     }
@@ -169,6 +171,7 @@
         
         // animate the drag view to the newly hovered cell
         if (_draggingView) {
+            [self tapticEngineFeedback];
             [UIView animateWithDuration:0.3
                              animations:^{
                                  if ([(id)_tableView.lprDelegate respondsToSelector:@selector(tableView:hideDraggingView:atIndexPath:)]) {
@@ -220,6 +223,8 @@
             NSLog(@"moveRowAtIndexPath:toIndexPath: is not implemented");
         }
         [_tableView endUpdates];
+        
+        [self tapticEngineFeedback];
         
         _currentIndexPath = newIndexPath;
     }
@@ -284,6 +289,18 @@
 - (void)removeDraggingView {
     [_draggingView removeFromSuperview];
     _draggingView = nil;
+}
+
+- (void)tapticEngineFeedback {
+    if ([[[UIDevice currentDevice] systemVersion] compare:@"10.0" options:NSNumericSearch] != NSOrderedAscending &&
+        [UIApplication sharedApplication].keyWindow.rootViewController.traitCollection.forceTouchCapability == UIForceTouchCapabilityAvailable) {
+        static UIImpactFeedbackGenerator *generator = nil;
+        if (!generator) {
+            generator = [UIImpactFeedbackGenerator new];
+            [generator prepare];
+        }
+        [generator impactOccurred];
+    }
 }
 
 @end


### PR DESCRIPTION
- New property for current dragging status.
- New property to scale the dragging view.
- New property to follow finger's position.
- Stop dragging immediately when longPressReorderEnabled is assigned to NO.
- Make sure the dragged cell is hidden after being dequeued.
- Make sure `showDraggingView:` and `hideDraggingView:` are called together with the default animations.
- Allow draggingView to go outside of the tableView.
- Add draggingView to tableView's window so that if `tableView.clipsToBound == YES`, the draggingView won't be truncated by tableView's edges.
- Use `snapshotViewAfterScreenUpdates:` instead of `renderInContext:` to be more efficient and to avoid the crash of `Texture PixelFormat MTLPixelFormatBGR10_XR_sRGB does not match Resolve PixelFormat MTLPixelFormatBGRA8Unorm_sRGB`.
- But when `snapshotViewAfterScreenUpdates:` isn't available, use `drawViewHierarchyInRect:` instead.
- Added Taptic Engine support.